### PR TITLE
Minor fixes

### DIFF
--- a/pkg/buildjob/build_manager.go
+++ b/pkg/buildjob/build_manager.go
@@ -97,6 +97,11 @@ func (r RealPodControl) deletePod(podID string) error {
 }
 
 func dockerfileBuildJobFor(job api.Job) (*api.Pod, error) {
+	var envVars []api.EnvVar
+	for k, v := range job.Context {
+		envVars = append(envVars, api.EnvVar{Name: k, Value: v})
+	}
+
 	pod := &api.Pod{
 		Labels: map[string]string{
 			"podType": "job",
@@ -111,10 +116,7 @@ func dockerfileBuildJobFor(job api.Job) (*api.Pod, error) {
 						Image:         "ironcladlou/openshift-docker-builder",
 						Privileged:    true,
 						RestartPolicy: "runOnce",
-						Env: []api.EnvVar{
-							{Name: "BUILD_TAG", Value: job.Context["BUILD_TAG"]},
-							{Name: "DOCKER_CONTEXT_URL", Value: job.Context["DOCKER_CONTEXT_URL"]},
-						},
+						Env:           envVars,
 					},
 				},
 			},

--- a/pkg/kubecfg/resource_printer.go
+++ b/pkg/kubecfg/resource_printer.go
@@ -89,7 +89,7 @@ var replicationControllerColumns = []string{"Name", "Image(s)", "Selector", "Rep
 var serviceColumns = []string{"Name", "Labels", "Selector", "Port"}
 var minionColumns = []string{"Minion identifier"}
 var statusColumns = []string{"Status"}
-var jobColumns = []string{"ID", "State"}
+var jobColumns = []string{"ID", "State", "Pod ID"}
 
 func (h *HumanReadablePrinter) unknown(data []byte, w io.Writer) error {
 	_, err := fmt.Fprintf(w, "Unknown object: %s", string(data))
@@ -132,7 +132,7 @@ func (h *HumanReadablePrinter) printPodList(podList *api.PodList, w io.Writer) e
 }
 
 func (h *HumanReadablePrinter) printJob(job *api.Job, w io.Writer) error {
-	_, err := fmt.Fprintf(w, "%s\t%s", job.ID, job.State)
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", job.ID, job.State, job.PodID)
 	return err
 }
 


### PR DESCRIPTION
Print newline after each job in kubecfg list jobs.
Pass the entire environment through to pods created from jobs.
